### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ pip install python-alipay-sdk
 refund 需要传入的参数参见[官方文档](https://doc.open.alipay.com/docs/api.htm?docType=4&apiId=759)的**请求参数**
 
 ```Python
-
+# 即时到账退款
 try:
-    alipay.refund(out_trade_no="xxx", refund_amount="xxx", ...)
+    alipay.refund_web_order(out_trade_no="xxx", refund_amount="xxx", ...)
 except AliPayException as e:
     raise e
 return True


### PR DESCRIPTION
说明文档退款这里，refund接口参数有误，看源码这个接口只是供内部使用，一般不会被外部直接调用，这里应该是个笔误，我随便改成了一个即时到账的接口例子。