### PR TITLE
调用api_alipay_trade_precreate方法时也会加上回调地址参数了.

### DIFF
--- a/alipay/__init__.py
+++ b/alipay/__init__.py
@@ -135,7 +135,7 @@ class BaseAliPay():
 
         if method in (
             "alipay.trade.app.pay", "alipay.trade.wap.pay", "alipay.trade.page.pay",
-            "alipay.trade.pay"
+            "alipay.trade.pay", "alipay.trade.precreate"
         ):
             if self._app_notify_url is not None:
                 data["notify_url"] = self._app_notify_url


### PR DESCRIPTION
之前的调用api_alipay_trade_precreate这个方法也就是扫码付款的时候，传参没传notify_url这个参数，不过扫码付款有时候还是需要支付宝的异步通知的，不知道是一个bug还是feature。