### PR TITLE
change dependency, replace pycryptodome with pycryptodomex

### DIFF
--- a/alipay/__init__.py
+++ b/alipay/__init__.py
@@ -7,9 +7,9 @@
 """
 import json
 from datetime import datetime
-from Crypto.Signature import PKCS1_v1_5
-from Crypto.Hash import SHA, SHA256
-from Crypto.PublicKey import RSA
+from Cryptodome.Signature import PKCS1_v1_5
+from Cryptodome.Hash import SHA, SHA256
+from Cryptodome.PublicKey import RSA
 
 from .compat import quote_plus, urlopen, decodebytes, encodebytes, b
 from .exceptions import AliPayException, AliPayValidationError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pycryptodome
+pycryptodomex
 mock==2.0.0
 codecov
 tox

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
     ],
-    install_requires=["pycryptodome"],
+    install_requires=["pycryptodomex"],
     test_suite="setup.alipay_test_suite"
 )


### PR DESCRIPTION
I'm using this package, and encountered with a problem, when I install this package, I could not use my installed `Pycrypto` normally, so I spent some time looking into it.

As a fork of `Pycrypto`, `Pycryptodome` use the same dictionary to install, and this could cause dependency problems. So here is a slightly merge request to resolve the problem:

According to [pycryptodome's doc](https://github.com/Legrandin/pycryptodome):
> a library independent of the old PyCrypto. You install it with:
    `pip install pycryptodomex`
    In this case, all modules are installed under the Cryptodome package. PyCrypto and PyCryptodome can coexist.

