### PR TITLE
support fund.trans.toaccount.transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## python-alipay-sdk
 [![PyPI version](https://badge.fury.io/py/python-alipay-sdk.svg)](https://badge.fury.io/py/python-alipay-sdk) [![codecov](https://codecov.io/gh/fzlee/alipay/branch/master/graph/badge.svg)](https://codecov.io/gh/fzlee/alipay) ![travis-ci](https://travis-ci.org/fzlee/alipay.svg?branch=master)
-## [中文文档](https://github.com/fzlee/alipay/blob/master/README.zh-hans.md)
+## [中文文档](./README.zh-hans.md)
 
 ##  Unofficial AliPay Python SDK
 
@@ -19,6 +19,7 @@ So far, the following functions are supported:
 * [Order Settlement](#alipay.trade.order.settle)
 * [Close Order](#alipay.trade.close)
 * [Transfer money to alipay account](#alipay.fund.trans.toaccount.transfer)
+* [DC transfer money to alipay account](#alipay.fund.trans.uni.transfer)
 * [Query money transfer result](#alipay.fund.trans.order.query)
 * [ISV integration/Get app_auth_code by app_auth_token](#alipay.open.auth.token.app)
 * [ISV integration/Query authorized apps](#alipay.open.auth.token.app.query)
@@ -387,6 +388,19 @@ result = {
     'out_biz_no': '', 
     'pay_date': '2017-06-26 14:36:25'
 }
+```
+
+#### <a name="alipay.fund.trans.uni.transfer"></a>[alipay.fund.trans.uni.transfer](https://opendocs.alipay.com/apis/api_28/alipay.fund.trans.uni.transfer)
+```python
+# Only support dc_client. Transfer money to alipay account
+result = dc_alipay.api_alipay_fund_trans_uni_transfer(
+    out_biz_no=datetime.now().strftime("%Y%m%d%H%M%S"),
+    identity_type="ALIPAY_LOGON_ID/ALIPAY_LOGON_ID",
+    identity="egdjny5218@sandbox.com",
+    trans_amount=82.32,
+    name="沙箱环境"
+)
+result = {'code': '10000', 'msg': 'Success', 'order_id': '', 'out_biz_no': '', 'status': 'SUCCESS'}
 ```
 
 #### <a name="alipay.fund.trans.order.query"></a> [alipay.fund.trans.order.query](https://docs.open.alipay.com/api_28/alipay.fund.trans.order.query)

--- a/README.zh-hans.md
+++ b/README.zh-hans.md
@@ -18,6 +18,7 @@
 * [统一收单交易结算接口](#alipay.trade.order.settle)
 * [统一收单交易关闭接口](#alipay.trade.close)
 * [单笔转账到支付宝账户接口](#alipay.fund.trans.toaccount.transfer)
+* [DC/单笔转账接口](#alipay.fund.trans.uni.transfer)
 * [查询转账订单接口](#alipay.fund.trans.order.query)
 * [ISV集成/生成app_auth_code](#alipay.open.auth.token.app)
 * [ISV集成/查询授权产品](#alipay.open.auth.token.app.query)
@@ -381,6 +382,19 @@ result = alipay.api_alipay_fund_trans_toaccount_transfer(
     amount=3.12
 )
 result = {'code': '10000', 'msg': 'Success', 'order_id': '', 'out_biz_no': '', 'pay_date': '2017-06-26 14:36:25'}
+```
+
+#### <a name="alipay.fund.trans.uni.transfer"></a>单笔转账接口 [alipay.fund.trans.uni.transfer](https://opendocs.alipay.com/apis/api_28/alipay.fund.trans.uni.transfer)
+```python
+# Only support dc_client. Transfer money to alipay account
+result = dc_alipay.api_alipay_fund_trans_uni_transfer(
+    out_biz_no=datetime.now().strftime("%Y%m%d%H%M%S"),
+    identity_type="ALIPAY_LOGON_ID/ALIPAY_LOGON_ID",
+    identity="egdjny5218@sandbox.com",
+    trans_amount=82.32,
+    name="沙箱环境"
+)
+result = {'code': '10000', 'msg': 'Success', 'order_id': '', 'out_biz_no': '', 'status': 'SUCCESS'}
 ```
 
 #### <a name="alipay.fund.trans.order.query"></a> 查询转账订单接口 [alipay.fund.trans.order.query](https://docs.open.alipay.com/api_28/alipay.fund.trans.order.query)

--- a/alipay/__init__.py
+++ b/alipay/__init__.py
@@ -719,6 +719,32 @@ class DCAliPay(BaseAliPay):
             self._alipay_root_cert_sn = self.get_root_cert_sn(self._alipay_root_cert_string)
         return getattr(self, "_alipay_root_cert_sn")
 
+    def api_alipay_fund_trans_uni_transfer(
+        self, out_biz_no, identity_type, identity, trans_amount, name=None, **kwargs
+    ):
+        """
+        单笔转账接口, 只支持公钥证书模式
+        文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.trans.uni.transfer
+        """
+        assert identity_type in ("ALIPAY_USER_ID", "ALIPAY_LOGON_ID"), "unknown identity type"
+
+        biz_content = {
+            "payee_info": {
+                "identity": identity,
+                "identity_type": identity_type,
+            },
+            "out_biz_no": out_biz_no,
+            "trans_amount": trans_amount,
+            "product_code": "TRANS_ACCOUNT_NO_PWD",
+            "biz_scene": "DIRECT_TRANSFER",
+        }
+        biz_content["payee_info"]["name"] = name if name else None
+        biz_content.update(kwargs)
+
+        response_type = "alipay_fund_trans_uni_transfer_response"
+        data = self.build_body("alipay.fund.trans.uni.transfer", biz_content)
+        return self.verified_sync_response(data, response_type)
+
 
 class ISVAliPay(BaseAliPay):
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -394,6 +394,9 @@ class DCAliPayTestCase(AliPayTestCase):
     def _prepare_create_face_to_face_response(self, alipay):
         return self._prepare_sync_response(alipay, "alipay_trade_pay_response")
 
+    def _prepare_alipay_fund_trans_uni_transfer_response(self, alipay):
+        return self._prepare_sync_response(alipay, "alipay_fund_trans_uni_transfer_response")
+
     def test_sign_data_with_private_key_sha256(self):
         """openssl 以及aliapy分别对数据进行签名，得到同样的结果
         """
@@ -421,6 +424,21 @@ class DCAliPayTestCase(AliPayTestCase):
             "subject"
         )
 
+        self.assertTrue(mock_urlopen.called)
+
+    @mock.patch("alipay.urlopen")
+    def test_alipay_fund_trans_uni_transfer(self, mock_urlopen):
+        alipay = self.get_client()
+        response = mock.Mock()
+        response.read.return_value = self._prepare_alipay_fund_trans_uni_transfer_response(alipay)
+        mock_urlopen.return_value = response
+
+        alipay.api_alipay_fund_trans_uni_transfer(
+            "out_biz_no",
+            "ALIPAY_LOGON_ID",
+            "alipay account",
+            8.88,
+        )
         self.assertTrue(mock_urlopen.called)
 
 


### PR DESCRIPTION
基于最近master分支，支持转账新接口 alipay.fund.trans.uni.transfer(单笔转账接口)，测试环境Python3.6.8

支付宝升级了转账接口，公司里有用到，且进行了升级，因为用到了该包，发现缺失这接口，刚好逻辑不算不太复杂，萌生了提交pr的想法（人生中第一个pr...），不过公司里的这个项目用的是py2，由于没有dc client，所以暂时不太好兼容到py2，魔改了一小部分代码，后期看看能否整理好也提交一个pr

转账到支付宝账户接口升级指南：https://opendocs.alipay.com/open/00ou7f
uni.transfer接口文档：https://opendocs.alipay.com/apis/api_28/alipay.fund.trans.uni.transfer

下图是自己使用沙箱账号进行的测试图，环境是Python3.6.8，如果需要我这边可以补充参数注释等信息：
![image](https://user-images.githubusercontent.com/22811481/104936223-2f406980-59e7-11eb-9374-d71dd91d8509.png)
