### PR TITLE
将`biz_content`改为可选传递参数

### DIFF
--- a/alipay/__init__.py
+++ b/alipay/__init__.py
@@ -136,7 +136,10 @@ class BaseAliPay:
                 data[k] = json.dumps(v, separators=(',', ':'))
         return sorted(data.items())
 
-    def build_body(self, method, biz_content, **kwargs):
+    def build_body(self, method, biz_content=None, **kwargs):
+        if not biz_content:
+            biz_content = {}
+            
         data = {
             "app_id": self._appid,
             "method": method,
@@ -201,17 +204,23 @@ class BaseAliPay:
         message = "&".join(u"{}={}".format(k, v) for k, v in unsigned_items)
         return self._verify(message, signature)
 
-    def client_api(self, api_name, biz_content, **kwargs):
+    def client_api(self, api_name, biz_content=None, **kwargs):
         """
         alipay api without http request
         """
+        if not biz_content:
+            biz_content = {}
+            
         data = self.build_body(api_name, biz_content, **kwargs)
         return self.sign_data(data)
 
-    def server_api(self, api_name, biz_content, **kwargs):
+    def server_api(self, api_name, biz_content=None, **kwargs):
         """
         alipay api with http request
         """
+        if not biz_content:
+            biz_content = {}
+
         data = self.build_body(api_name, biz_content, **kwargs)
         # alipay.trade.query => alipay_trade_query_response
         response_type = api_name.replace(".", "_") + "_response"


### PR DESCRIPTION
在某些接口中（如[门店类目配置查询接口 - 支付宝文档中心](https://opendocs.alipay.com/open/02bxoy)），请求参数可能都是可选参数，这个时候，用户不传参数，接口中的 `biz_content` 可以默认传空保证正确处理。